### PR TITLE
Ability to see entire song and album title

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectAlbumActivity.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectAlbumActivity.java
@@ -145,15 +145,22 @@ public class SelectAlbumActivity extends SubsonicTabActivity
 			public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
 				if (view instanceof AlbumView) {
 					AlbumView albumView = (AlbumView) view;
-					albumView.maximizeOrMinimize();
+					if (!albumView.isMaximized()) {
+						albumView.maximizeOrMinimize();
+						return true;
+					} else {
+						return false;
+					}
 				}
 				if (view instanceof SongView) {
 					SongView songView = (SongView) view;
 					songView.maximizeOrMinimize();
+					return true;
 				}
-				return true;
+				return false;
 			}
 		});
+
 
 		selectButton = (ImageView) findViewById(R.id.select_album_select);
 		playNowButton = (ImageView) findViewById(R.id.select_album_play_now);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectAlbumActivity.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectAlbumActivity.java
@@ -27,6 +27,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.ImageView;
 import android.widget.ListView;
@@ -104,6 +105,31 @@ public class SelectAlbumActivity extends SubsonicTabActivity
 			public void onRefresh(PullToRefreshBase<ListView> refreshView)
 			{
 				new GetDataTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+			}
+		});
+
+		refreshAlbumListView.setOnScrollListener(new AbsListView.OnScrollListener() {
+			@Override
+			public void onScrollStateChanged(AbsListView view, int scrollState) {
+				for (int i=0;i<albumListView.getChildCount();i++) {
+					Object child = albumListView.getChildAt(i);
+					if (child instanceof AlbumView) {
+						AlbumView albumView = (AlbumView) child;
+						if (albumView.isMaximized()) {
+							albumView.maximizeOrMinimize();
+						}
+					}
+					if (child instanceof SongView) {
+						SongView songView = (SongView) child;
+                        if (songView.isMaximized()) {
+                            songView.maximizeOrMinimize();
+                        }
+					}
+				}
+			}
+
+			@Override
+			public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
 			}
 		});
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectAlbumActivity.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectAlbumActivity.java
@@ -46,7 +46,9 @@ import org.moire.ultrasonic.util.EntryByDiscAndTrackComparator;
 import org.moire.ultrasonic.util.Pair;
 import org.moire.ultrasonic.util.TabActivityBackgroundTask;
 import org.moire.ultrasonic.util.Util;
+import org.moire.ultrasonic.view.AlbumView;
 import org.moire.ultrasonic.view.EntryAdapter;
+import org.moire.ultrasonic.view.SongView;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -134,6 +136,22 @@ public class SelectAlbumActivity extends SubsonicTabActivity
 						enableButtons();
 					}
 				}
+			}
+		});
+
+		albumListView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener(){
+
+			@Override
+			public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
+				if (view instanceof AlbumView) {
+					AlbumView albumView = (AlbumView) view;
+					albumView.maximizeOrMinimize();
+				}
+				if (view instanceof SongView) {
+					SongView songView = (SongView) view;
+					songView.maximizeOrMinimize();
+				}
+				return true;
 			}
 		});
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
@@ -95,6 +95,10 @@ public class AlbumView extends UpdateView
 		return this.entry;
 	}
 
+	public boolean isMaximized() {
+		return maximized;
+	}
+
 	public void maximizeOrMinimize() {
 		if (maximized) {
 			maximized = false;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
@@ -49,6 +49,7 @@ public class AlbumView extends UpdateView
 	private MusicDirectory.Entry entry;
 	private EntryAdapter.AlbumViewHolder viewHolder;
 	private ImageLoader imageLoader;
+	private boolean maximized = false;
 
 	public AlbumView(Context context, ImageLoader imageLoader)
 	{
@@ -92,6 +93,20 @@ public class AlbumView extends UpdateView
 	public MusicDirectory.Entry getEntry()
 	{
 		return this.entry;
+	}
+
+	public void maximizeOrMinimize() {
+		if (maximized) {
+			maximized = false;
+		} else {
+			maximized = true;
+		}
+		if (this.viewHolder.title != null) {
+			this.viewHolder.title.setSingleLine(!maximized);
+		}
+		if (this.viewHolder.artist != null) {
+			this.viewHolder.artist.setSingleLine(!maximized);
+		}
 	}
 
 	public void setAlbum(final MusicDirectory.Entry album)

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/SongView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/SongView.java
@@ -71,6 +71,7 @@ public class SongView extends UpdateView implements Checkable
 	private DownloadFile downloadFile;
 	private boolean playing;
 	private EntryAdapter.SongViewHolder viewHolder;
+	private boolean maximized = false;
 
 	public SongView(Context context)
 	{
@@ -425,6 +426,20 @@ public class SongView extends UpdateView implements Checkable
 	public void toggle()
 	{
 		viewHolder.check.toggle();
+	}
+
+	public void maximizeOrMinimize() {
+		if (maximized) {
+			maximized = false;
+		} else {
+			maximized = true;
+		}
+		if (this.viewHolder.title != null) {
+			this.viewHolder.title.setSingleLine(!maximized);
+		}
+		if (this.viewHolder.artist != null) {
+			this.viewHolder.artist.setSingleLine(!maximized);
+		}
 	}
 
 	public enum ImageType

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/SongView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/SongView.java
@@ -428,6 +428,10 @@ public class SongView extends UpdateView implements Checkable
 		viewHolder.check.toggle();
 	}
 
+	public boolean isMaximized() {
+		return maximized;
+	}
+
 	public void maximizeOrMinimize() {
 		if (maximized) {
 			maximized = false;


### PR DESCRIPTION
In Ultrasonic, album lists and songs lists alway show titles/artits on one line thus they are truncated if too long.

That is annoying so I created this fix. Now, when you long click on an item in a list, the item will be displayed on more lines if it's long and you will be able to see the title entirely. 
When scroll, the item returns to the reduced form.